### PR TITLE
Build fixes: FAA API host, GDAL 3.12, SpatiaLite 5, macOS portability

### DIFF
--- a/create_databases.sh
+++ b/create_databases.sh
@@ -22,7 +22,7 @@ if [ ! -f "$nasr28dayFileName" ]; 	then
 	fi
 
 # Get command line parameter and construct the full path to the unzipped data
-datadir=$(readlink -m "$(dirname "$nasr28dayFileName")")
+datadir=$(cd "$(dirname "$nasr28dayFileName")" && pwd)
 datadir+="/"
 datadir+=$(basename "$nasr28dayFileName" .zip)
 datadir+="/"
@@ -54,11 +54,11 @@ if [ ! -d "$controlled_airspace_input_directory" ]; 	then
  	fi
 
 # Delete any existing files
-rm --force "$nasr_database"
-rm --force "$nasr_spatialite_database"
-rm --force ./DAILY_DOF_DAT.ZIP ./DOF.DAT
-rm --force "$controlled_airspace_spatialite_database"
-rm --force "$special_use_airspace_spatialite_database"
+rm -f "$nasr_database"
+rm -f "$nasr_spatialite_database"
+rm -f ./DAILY_DOF_DAT.ZIP ./DOF.DAT
+rm -f "$controlled_airspace_spatialite_database"
+rm -f "$special_use_airspace_spatialite_database"
 
 # Get the daily obstacle file
 echo "---------- Download and process daily obstacle file"
@@ -80,9 +80,18 @@ sqlite3 "$nasr_database" < add_indexes.sql
 echo "---------- Create the spatialite version of database"
 cp "$nasr_database" "$nasr_spatialite_database"
 
-# Convert the copy to spatialite
+# Convert the copy to spatialite. macOS system sqlite3 has
+# SQLITE_OMIT_LOAD_EXTENSION; need a binary that supports load_extension.
+# Prefer Homebrew's sqlite when present.
+SQLITE_BIN=sqlite3
+if [ -x /opt/homebrew/opt/sqlite/bin/sqlite3 ]; then
+    SQLITE_BIN=/opt/homebrew/opt/sqlite/bin/sqlite3
+fi
+# sqlite_to_spatialite.sql tries multiple paths for mod_spatialite; the
+# unsuccessful candidates emit "Error near line ..." messages and return
+# nonzero, but the build still completes via whichever path resolves first.
 set +e
-sqlite3 "$nasr_spatialite_database" < sqlite_to_spatialite.sql
+"$SQLITE_BIN" "$nasr_spatialite_database" < sqlite_to_spatialite.sql
 set -e
 
 # Lump the airspaces into spatialite databases

--- a/create_databases.sh
+++ b/create_databases.sh
@@ -112,7 +112,6 @@ find "$sua_input_directory" \
     -lco LAUNDER=NO         \
     --config OGR_SQLITE_SYNCHRONOUS OFF \
     --config OGR_SQLITE_CACHE 128       \
-    -gt 65536                           \
     \;
 
 ogrinfo "$special_use_airspace_spatialite_database" -sql "VACUUM"
@@ -136,7 +135,6 @@ find "$controlled_airspace_input_directory" \
     -nlt MULTIPOLYGONZ      \
     --config OGR_SQLITE_SYNCHRONOUS OFF \
     --config OGR_SQLITE_CACHE 128       \
-    -gt 65536                           \
     -progress  \
   \;
 

--- a/get_current_nasr_url.py
+++ b/get_current_nasr_url.py
@@ -6,7 +6,7 @@ import errno, sys
 
 # The URL to get data from
 # "edition=next" to get the upcoming edition
-url="https://soa.smext.faa.gov/apra/nfdc/nasr/chart?edition=current"
+url="https://external-api.faa.gov/apra/nfdc/nasr/chart?edition=current"
 
 # Some sample JSON for testing with
 sample_json="""

--- a/sqlite_to_spatialite.sql
+++ b/sqlite_to_spatialite.sql
@@ -1,17 +1,27 @@
 -- PRAGMA foreign_keys=ON;
 PRAGMA synchronous=OFF;
+-- SpatiaLite 5+ uses RTreeAlign() inside CreateSpatialIndex; the SQLite
+-- "untrusted schema" guard rejects it. Enable trusted_schema or every
+-- spatial-index creation aborts the batch before the geometry UPDATEs run
+-- (leaving geometry columns populated structurally but with NULL data).
+PRAGMA trusted_schema=ON;
 -- PRAGMA journal_mode=MEMORY;
 -- PRAGMA default_cache_size=10000;
 -- PRAGMA locking_mode=EXCLUSIVE;
 
--- The old way of loading spatialite
--- SELECT load_extension('libspatialite.so');
--- The new way
--- See https://www.gaia-gis.it/fossil/libspatialite/wiki?name=mod_spatialite
+-- Try several candidate paths for mod_spatialite. The first one that
+-- resolves wins; sqlite3 continues past failures in batch mode, so this is
+-- safe even when most paths don't exist. Order matters only for noise in
+-- stderr — functionality is unaffected once any one succeeds.
+--   * bare name: works on Linux when the loader's search path includes the
+--     SpatiaLite install dir (e.g. Ubuntu's /usr/lib/x86_64-linux-gnu).
+--   * .so suffix: alternate Linux name; some packages register both.
+--   * /opt/homebrew/lib: macOS Apple Silicon Homebrew default.
+--   * /usr/local/lib:    macOS Intel Homebrew default.
 SELECT load_extension('mod_spatialite');
--- 2018-06-08 added the .so extension because module stopped loading
---            I'm leaving the original line in as well
 SELECT load_extension('mod_spatialite.so');
+SELECT load_extension('/opt/homebrew/lib/mod_spatialite');
+SELECT load_extension('/usr/local/lib/mod_spatialite');
 SELECT InitSpatialMetadata(1);
 
 /*


### PR DESCRIPTION
Three independent issues that broke the NASR build on macOS Tahoe + GDAL 3.12 + SpatiaLite 5. The first two affect every platform; only the third is macOS-specific. Each is committed separately so they can be cherry-picked individually if preferred.

## 1. FAA NASR API hostname change (universal)

`soa.smext.faa.gov` no longer resolves — the FAA migrated their public NASR catalog endpoint to `external-api.faa.gov`. Same JSON schema; only the hostname needs updating in `get_current_nasr_url.py`.

Verified by:

    curl -s 'https://external-api.faa.gov/apra/nfdc/nasr/chart?edition=current'

returns `{"status":...,"edition":[{...,"product":{"url":"...28DaySubscription_Effective_YYYY-MM-DD.zip"}}]}`.

## 2. GDAL 3.12 + SpatiaLite 5 compatibility (universal)

Two latent breakages exposed by recent toolchain releases:

**GDAL 3.12** made `-gt <n>` and `-skipfailures` mutually exclusive in `ogr2ogr`:

    ERROR 1: Argument '-gt <n>|unlimited' not allowed with '-skip/-skipfailures'

Both `ogr2ogr` calls in this script use `-skipfailures` (essential for the SUA AIXM XML batch where a few files always fail to parse), so the `-gt 65536` lines must go on any GDAL ≥ 3.12. The flag was a transaction-size hint for performance, not correctness — output is identical.

**SpatiaLite 5**'s `CreateSpatialIndex()` invokes `RTreeAlign()` internally, which the SQLite "untrusted schema" guard rejects with `unsafe use of RTreeAlign()`. This is silently catastrophic: the SQL batch aborts before any of the geometry-population `UPDATE … SET … = MakePoint(...)` statements run, so the `*Geom` columns get added to the schema but never populated. The build "succeeds" but produces a spatialite database with empty geometry columns and broken spatial queries. Adding `PRAGMA trusted_schema=ON;` at the top of `sqlite_to_spatialite.sql` allows the function and lets the batch complete normally.

Also makes the `mod_spatialite` load portable: previously only `mod_spatialite` and `mod_spatialite.so` were attempted. macOS Homebrew puts the lib at `/opt/homebrew/lib/mod_spatialite` and Apple-Silicon sqlite child processes don't have that prefix in the dynamic-loader search path. The script now tries that path plus `/usr/local/lib` (Intel Homebrew) as additional candidates. SQLite continues past failed `load_extension` calls in batch mode, so the unused candidates are harmless noise.

## 3. macOS portability (macOS-only)

Three small accommodations that don't affect Linux behaviour:

- `readlink -m` is GNU-only; replaced with the POSIX `(cd "$(dirname "$path")" && pwd)` idiom (functionally equivalent — the path always exists by the time we reach this line).
- `rm --force` is GNU long-form; replaced with `rm -f` which both GNU and BSD accept.
- Apple's stock `/usr/bin/sqlite3` is built with `SQLITE_OMIT_LOAD_EXTENSION`, so the spatialite SQL batch silently produces empty geometry columns. Prefer `/opt/homebrew/opt/sqlite/bin/sqlite3` if installed; on Linux that path doesn't exist, so the picker falls through to the system `sqlite3` unchanged.

## Testing

End-to-end build verified on macOS Tahoe 26.2 against the 2026-04-16 NASR cycle. All four output databases populate correctly:

| File | Rows | Notes |
|---|---|---|
| `nasr.sqlite` | ~70 NASR tables, full row counts vs prior cycle | |
| `spatialite_nasr.sqlite` | 34 spatial layers, all geometry columns populated | (was the silent failure mode without the trusted_schema fix) |
| `controlled_airspace_spatialite.sqlite` | Class B/C/D/E shelves, 5,612 rows | |
| `special_use_airspace_spatialite.sqlite` | AIXM SUA, 1,236 rows | |

I haven't tested on Ubuntu directly, but all the universal-fix changes are either dropping a flag (`-gt`), adding a PRAGMA that is no-op when not needed, or extending an existing search list — none should regress existing Ubuntu installs. The macOS-only changes either fall through to existing behaviour (sqlite3 picker) or are pure flag-form swaps that both libcs accept (`rm -f`, the `cd && pwd` idiom).
